### PR TITLE
Update highlight.gemspec

### DIFF
--- a/highlight.gemspec
+++ b/highlight.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.license                   = 'MIT'
   s.require_path              = 'lib'
   s.rubygems_version          = %q{1.3.0}
-  s.has_rdoc                  = false
   s.summary                   = %q{Syntax Higlighting plugin for Ruby on Rails }
   s.description               = %q{Highlight highlights code in more than 20 languages. It uses the Pygments syntax highlighter and adds a simple Ruby API over it. It also provides helpers for use in your Ruby on Rails views.}
 


### PR DESCRIPTION
@dionlarson `has_rdoc` is deprecated:

```ruby
$ bundle install
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/lucasarruda/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/bundler/gems/highlight-9deb7e06cc37/highlight.gemspec:27.
```